### PR TITLE
fix: emb req accept list of tokens

### DIFF
--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PY_SOURCE=llmspec
+PY_SOURCE=llmspec tests
 
 .DEFAULT_GOAL:=build
 
@@ -6,12 +6,10 @@ build:
 	@pdm build
 
 lint:
-	@black --check --diff ${PY_SOURCE}
-	@ruff check .
+	@ruff check ${PY_SOURCE}
 
 format:
-	@black ${PY_SOURCE}
-	@ruff check --fix .
+	@ruff format ${PY_SOURCE}
 
 test:
 	@pytest -vv -s

--- a/llmspec/llmspec.py
+++ b/llmspec/llmspec.py
@@ -180,9 +180,11 @@ class ChatResponse(LMResponse):
 
 class EmbeddingRequest(msgspec.Struct, JSONSerializableMixin):
     model: str
-    input: Union[str, List[str], List[List[int]]]
-    user: str = ""
-    encoding_format: str = "float"
+    # this is not strict correct, but in Python,
+    # "Type unions may not contain more than one array-like type"
+    input: Union[str, List[Union[str, List[int]]]]
+    user: Optional[str] = ""
+    encoding_format: Optional[str] = "float"
 
 
 class EmbeddingData(msgspec.Struct):

--- a/llmspec/llmspec.py
+++ b/llmspec/llmspec.py
@@ -1,3 +1,8 @@
+"""
+Reference:
+- https://platform.openai.com/docs/api-reference
+"""
+
 from __future__ import annotations
 
 import time
@@ -174,10 +179,10 @@ class ChatResponse(LMResponse):
 
 
 class EmbeddingRequest(msgspec.Struct, JSONSerializableMixin):
-    model: str = ""
-    input: Union[str, List[str]] = None
+    model: str
+    input: Union[str, List[str], List[List[int]]]
     user: str = ""
-    encoding_format: str = "json"
+    encoding_format: str = "float"
 
 
 class EmbeddingData(msgspec.Struct):

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,30 +2,6 @@
 # It is not intended for manual editing.
 
 [[package]]
-name = "black"
-version = "23.3.0"
-requires_python = ">=3.7"
-summary = "The uncompromising code formatter."
-dependencies = [
-    "click>=8.0.0",
-    "mypy-extensions>=0.4.3",
-    "packaging>=22.0",
-    "pathspec>=0.9.0",
-    "platformdirs>=2",
-    "tomli>=1.1.0; python_version < \"3.11\"",
-    "typing-extensions>=3.10.0.0; python_version < \"3.10\"",
-]
-
-[[package]]
-name = "click"
-version = "8.1.3"
-requires_python = ">=3.7"
-summary = "Composable command line interface toolkit"
-dependencies = [
-    "colorama; platform_system == \"Windows\"",
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
@@ -33,7 +9,7 @@ summary = "Cross-platform colored terminal text."
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.1"
+version = "1.1.3"
 requires_python = ">=3.7"
 summary = "Backport of PEP 654 (exception groups)"
 
@@ -45,43 +21,25 @@ summary = "brain-dead simple config-ini parsing"
 
 [[package]]
 name = "msgspec"
-version = "0.15.0"
+version = "0.18.4"
 requires_python = ">=3.8"
 summary = "A fast serialization and validation library, with builtin support for JSON, MessagePack, YAML, and TOML."
 
 [[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-requires_python = ">=3.5"
-summary = "Type system extensions for programs checked with the mypy type checker."
-
-[[package]]
 name = "packaging"
-version = "23.1"
+version = "23.2"
 requires_python = ">=3.7"
 summary = "Core utilities for Python packages"
 
 [[package]]
-name = "pathspec"
-version = "0.11.1"
-requires_python = ">=3.7"
-summary = "Utility library for gitignore style pattern matching of file paths."
-
-[[package]]
-name = "platformdirs"
-version = "3.5.1"
-requires_python = ">=3.7"
-summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-
-[[package]]
 name = "pluggy"
-version = "1.0.0"
-requires_python = ">=3.6"
+version = "1.3.0"
+requires_python = ">=3.8"
 summary = "plugin and hook calling mechanisms for python"
 
 [[package]]
 name = "pytest"
-version = "7.3.1"
+version = "7.4.3"
 requires_python = ">=3.7"
 summary = "pytest: simple powerful testing with Python"
 dependencies = [
@@ -95,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "ruff"
-version = "0.0.267"
+version = "0.1.3"
 requires_python = ">=3.7"
 summary = "An extremely fast Python linter, written in Rust."
 
@@ -105,141 +63,95 @@ version = "2.0.1"
 requires_python = ">=3.7"
 summary = "A lil' TOML parser"
 
-[[package]]
-name = "typing-extensions"
-version = "4.5.0"
-requires_python = ">=3.7"
-summary = "Backported and Experimental Type Hints for Python 3.7+"
-
 [metadata]
 lock_version = "4.2"
 cross_platform = true
-groups = ["default", "dev", "lint", "test"]
-content_hash = "sha256:0682e98c77a3b8d23438a8741c39cb6d2a59858794dc6d48186aa9dc746f3360"
+groups = ["default", "lint", "test"]
+content_hash = "sha256:f9c0d3abfb25b45ef5a4f9a3cd3669c1c790e688c08c878f6e37719cccee541b"
 
 [metadata.files]
-"black 23.3.0" = [
-    {url = "https://files.pythonhosted.org/packages/06/1e/273d610249f0335afb1ddb03664a03223f4826e3d1a95170a0142cb19fb4/black-23.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:6b39abdfb402002b8a7d030ccc85cf5afff64ee90fa4c5aebc531e3ad0175ddb"},
-    {url = "https://files.pythonhosted.org/packages/12/4b/99c71d1cf1353edd5aff2700b8960f92e9b805c9dab72639b67dbb449d3a/black-23.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:562bd3a70495facf56814293149e51aa1be9931567474993c7942ff7d3533961"},
-    {url = "https://files.pythonhosted.org/packages/13/0a/ed8b66c299e896780e4528eed4018f5b084da3b9ba4ee48328550567d866/black-23.3.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:064101748afa12ad2291c2b91c960be28b817c0c7eaa35bec09cc63aa56493c5"},
-    {url = "https://files.pythonhosted.org/packages/13/25/cfa06788d0a936f2445af88f13604b5bcd5c9d050db618c718e6ebe66f74/black-23.3.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:3238f2aacf827d18d26db07524e44741233ae09a584273aa059066d644ca7b30"},
-    {url = "https://files.pythonhosted.org/packages/21/14/d5a2bec5fb15f9118baab7123d344646fac0b1c6939d51c2b05259cd2d9c/black-23.3.0-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:714290490c18fb0126baa0fca0a54ee795f7502b44177e1ce7624ba1c00f2331"},
-    {url = "https://files.pythonhosted.org/packages/24/eb/2d2d2c27cb64cfd073896f62a952a802cd83cf943a692a2f278525b57ca9/black-23.3.0-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:1d06691f1eb8de91cd1b322f21e3bfc9efe0c7ca1f0e1eb1db44ea367dff656b"},
-    {url = "https://files.pythonhosted.org/packages/27/70/07aab2623cfd3789786f17e051487a41d5657258c7b1ef8f780512ffea9c/black-23.3.0-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:67de8d0c209eb5b330cce2469503de11bca4085880d62f1628bd9972cc3366b9"},
-    {url = "https://files.pythonhosted.org/packages/29/b1/b584fc863c155653963039664a592b3327b002405043b7e761b9b0212337/black-23.3.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:7c3eb7cea23904399866c55826b31c1f55bbcd3890ce22ff70466b907b6775c2"},
-    {url = "https://files.pythonhosted.org/packages/3c/d7/85f3d79f9e543402de2244c4d117793f262149e404ea0168841613c33e07/black-23.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a150542a204124ed00683f0db1f5cf1c2aaaa9cc3495b7a3b5976fb136090ab"},
-    {url = "https://files.pythonhosted.org/packages/3f/0d/81dd4194ce7057c199d4f28e4c2a885082d9d929e7a55c514b23784f7787/black-23.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:11c410f71b876f961d1de77b9699ad19f939094c3a677323f43d7a29855fe326"},
-    {url = "https://files.pythonhosted.org/packages/49/36/15d2122f90ff1cd70f06892ebda777b650218cf84b56b5916a993dc1359a/black-23.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50cb33cac881766a5cd9913e10ff75b1e8eb71babf4c7104f2e9c52da1fb7de2"},
-    {url = "https://files.pythonhosted.org/packages/49/d7/f3b7da6c772800f5375aeb050a3dcf682f0bbeb41d313c9c2820d0156e4e/black-23.3.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:92c543f6854c28a3c7f39f4d9b7694f9a6eb9d3c5e2ece488c327b6e7ea9b266"},
-    {url = "https://files.pythonhosted.org/packages/69/49/7e1f0cf585b0d607aad3f971f95982cc4208fc77f92363d632d23021ee57/black-23.3.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:a6f6886c9869d4daae2d1715ce34a19bbc4b95006d20ed785ca00fa03cba312d"},
-    {url = "https://files.pythonhosted.org/packages/6d/b4/0f13ab7f5e364795ff82b76b0f9a4c9c50afda6f1e2feeb8b03fdd7ec57d/black-23.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32daa9783106c28815d05b724238e30718f34155653d4d6e125dc7daec8e260c"},
-    {url = "https://files.pythonhosted.org/packages/ad/e7/4642b7f462381799393fbad894ba4b32db00870a797f0616c197b07129a9/black-23.3.0-py3-none-any.whl", hash = "sha256:ec751418022185b0c1bb7d7736e6933d40bbb14c14a0abcf9123d1b159f98dd4"},
-    {url = "https://files.pythonhosted.org/packages/c0/53/42e312c17cfda5c8fc4b6b396a508218807a3fcbb963b318e49d3ddd11d5/black-23.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f3c333ea1dd6771b2d3777482429864f8e258899f6ff05826c3a4fcc5ce3f70"},
-    {url = "https://files.pythonhosted.org/packages/ca/44/eb41edd3f558a6139f09eee052dead4a7a464e563b822ddf236f5a8ee286/black-23.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e114420bf26b90d4b9daa597351337762b63039752bdf72bf361364c1aa05925"},
-    {url = "https://files.pythonhosted.org/packages/ce/f4/2b0c6ac9e1f8584296747f66dd511898b4ebd51d6510dba118279bff53b6/black-23.3.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:48f9d345675bb7fbc3dd85821b12487e1b9a75242028adad0333ce36ed2a6d27"},
-    {url = "https://files.pythonhosted.org/packages/d1/6e/5810b6992ed70403124c67e8b3f62858a32b35405177553f1a78ed6b6e31/black-23.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:e198cf27888ad6f4ff331ca1c48ffc038848ea9f031a3b40ba36aced7e22f2c8"},
-    {url = "https://files.pythonhosted.org/packages/d6/36/66370f5017b100225ec4950a60caeef60201a10080da57ddb24124453fba/black-23.3.0.tar.gz", hash = "sha256:1c7b8d606e728a41ea1ccbd7264677e494e87cf630e399262ced92d4a8dac940"},
-    {url = "https://files.pythonhosted.org/packages/d7/6f/d3832960a3b646b333b7f0d80d336a3c123012e9d9d5dba4a622b2b6181d/black-23.3.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:a8a968125d0a6a404842fa1bf0b349a568634f856aa08ffaff40ae0dfa52e7c6"},
-    {url = "https://files.pythonhosted.org/packages/db/f4/7908f71cc71da08df1317a3619f002cbf91927fb5d3ffc7723905a2113f7/black-23.3.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:0945e13506be58bf7db93ee5853243eb368ace1c08a24c65ce108986eac65915"},
-    {url = "https://files.pythonhosted.org/packages/de/b4/76f152c5eb0be5471c22cd18380d31d188930377a1a57969073b89d6615d/black-23.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:35d1381d7a22cc5b2be2f72c7dfdae4072a3336060635718cc7e1ede24221d6c"},
-    {url = "https://files.pythonhosted.org/packages/eb/a5/17b40bfd9b607b69fa726b0b3a473d14b093dcd5191ea1a1dd664eccfee3/black-23.3.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:c7ab5790333c448903c4b721b59c0d80b11fe5e9803d8703e84dcb8da56fec1b"},
-    {url = "https://files.pythonhosted.org/packages/fd/5b/fc2d7922c1a6bb49458d424b5be71d251f2d0dc97be9534e35d171bdc653/black-23.3.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:f0bd2f4a58d6666500542b26354978218a9babcdc972722f4bf90779524515f3"},
-]
-"click 8.1.3" = [
-    {url = "https://files.pythonhosted.org/packages/59/87/84326af34517fca8c58418d148f2403df25303e02736832403587318e9e8/click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
-    {url = "https://files.pythonhosted.org/packages/c2/f1/df59e28c642d583f7dacffb1e0965d0e00b218e0186d7858ac5233dce840/click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
-]
 "colorama 0.4.6" = [
     {url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-"exceptiongroup 1.1.1" = [
-    {url = "https://files.pythonhosted.org/packages/61/97/17ed81b7a8d24d8f69b62c0db37abbd8c0042d4b3fc429c73dab986e7483/exceptiongroup-1.1.1-py3-none-any.whl", hash = "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e"},
-    {url = "https://files.pythonhosted.org/packages/cc/38/57f14ddc8e8baeddd8993a36fe57ce7b4ba174c35048b9a6d270bb01e833/exceptiongroup-1.1.1.tar.gz", hash = "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"},
+"exceptiongroup 1.1.3" = [
+    {url = "https://files.pythonhosted.org/packages/ad/83/b71e58666f156a39fb29417e4c8ca4bc7400c0dd4ed9e8842ab54dc8c344/exceptiongroup-1.1.3-py3-none-any.whl", hash = "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"},
+    {url = "https://files.pythonhosted.org/packages/c2/e1/5561ad26f99b7779c28356f73f69a8b468ef491d0f6adf20d7ed0ac98ec1/exceptiongroup-1.1.3.tar.gz", hash = "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9"},
 ]
 "iniconfig 2.0.0" = [
     {url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
     {url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
 ]
-"msgspec 0.15.0" = [
-    {url = "https://files.pythonhosted.org/packages/00/e7/79c4fac7145b3b4db3fe7865c7df563bda8ce4907852b6f41df4f005b4f1/msgspec-0.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:07ee1d1a15e3b319dcd7326470216928a7b58d47460b253577ccd0ab5dcf5c3c"},
-    {url = "https://files.pythonhosted.org/packages/02/fc/5883d85fdd50b709ae3713dffc4555d9d78d4dcb9b8792a89bc52a266d7c/msgspec-0.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ddef8fdc06676dd1bec9fe67b3128f84079469ee6424384cbb29a90c9033b559"},
-    {url = "https://files.pythonhosted.org/packages/09/a7/22e98b4ea8f18a192ce3733ff4ea12988c00da66a8fccd9048b006a7ad31/msgspec-0.15.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:beb3789519253b22338cca48053ba5ac8b442633e3af8f58e264d776a98ff6d0"},
-    {url = "https://files.pythonhosted.org/packages/09/fb/d2a7faf2f0b1de216e18871aa3eef9be470eeb8e6ae7bdb6272c1c6ea60f/msgspec-0.15.0-cp38-cp38-win_amd64.whl", hash = "sha256:cd198ed4445914ebc25a24b6cc6020902bb6b888fc9b39500ef4500841b1b437"},
-    {url = "https://files.pythonhosted.org/packages/0b/08/fb5c1c7cadbaf7cbad71f6b0ebef19127b0333adc76b57ffe794dafe8935/msgspec-0.15.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1b5b7c1b69416eab3ab2ad1c9593b749226b80555532292fae5fe9d154794089"},
-    {url = "https://files.pythonhosted.org/packages/22/05/43cc25daa884ac60282bba0717ab649510c74167757e365c844bedf6f248/msgspec-0.15.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fffa7ec85f27577f7f5471b390bf902d58ccd89b3612cf40bfb92f4ba75e6c95"},
-    {url = "https://files.pythonhosted.org/packages/2d/cb/adf40e298dc06cb25e61724bea00e7dd557bef1c3c0e34203577bf3b5502/msgspec-0.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0c75fd847709e30265f050375c408fec1c07797694162834aa86ab3b3cf055da"},
-    {url = "https://files.pythonhosted.org/packages/35/bc/296309f75a5f7851a3f88f0bfb0250662730555f9ed3a18509fb523bb7b7/msgspec-0.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:8b7e0354c37b742e1c02fe0cd3ced97db516c8da62ac5a408609e9f5858aaf24"},
-    {url = "https://files.pythonhosted.org/packages/37/da/4a8669ed5375e888df1916db69ee79393c6e0dd91a5fd9966df9f071cdba/msgspec-0.15.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:bf3ab3f8d5752dbe68babc77d21b42575b916793515442e3890aef680e212154"},
-    {url = "https://files.pythonhosted.org/packages/3a/66/f5bd979eaaeade2dfff01cca6e2f754e19d3cd68d9a7e348ce0de123d66d/msgspec-0.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:f77cc91d3cb8a7bccfba28fe4aec537178384509bfce222f8eca287b7e5d0214"},
-    {url = "https://files.pythonhosted.org/packages/40/f1/40604fdf74bfa93635d86ac2116f9d332e65a16e60c70855f4b96070c610/msgspec-0.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2b57b6869ef1717c0343465198e19284d1e6aa5f292af2726284e4dfedfedeef"},
-    {url = "https://files.pythonhosted.org/packages/4e/30/ff5f241aae54d4795606bc0755807b2e9781fa79112dd4b421fc45ea765b/msgspec-0.15.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:05fc603508e0c8021249d3e531fa4bb72d167bdfa76d869d48f96a5b8f9b50bf"},
-    {url = "https://files.pythonhosted.org/packages/5a/d4/904b58771c4a1d658c3050db56720daa54c4ec0563e60e2ff60283e09c23/msgspec-0.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:346960762d648a6512b51f30be7c1267630e0bbc6fd65e8b23a3f54e5f562656"},
-    {url = "https://files.pythonhosted.org/packages/6e/fc/75a4b7128bd9b3b323cae91549b8ed233b580808ba72b0172de3922207d8/msgspec-0.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff80bd40469915cc61686086a2503b901e17040f8a191099d8ccaa45dc72df8c"},
-    {url = "https://files.pythonhosted.org/packages/79/51/5d511271d5504f240d12095441f414365bea1f28bdbf6536e8b7f1b00c79/msgspec-0.15.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:490c88d76d573cce16653434ace3d9a8a8675ef6e350f114752fe60e69b6a232"},
-    {url = "https://files.pythonhosted.org/packages/81/34/33fb589280fcb05d10fdfbf08c205c2acd493def18befa801c57b0b751b0/msgspec-0.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8a46a9818570362d4022161684cdb97ecd102953043059ee4902862940f48f8d"},
-    {url = "https://files.pythonhosted.org/packages/8a/4e/0840fd02912d095bbed686e4f4e2c84947fec8c6e08fbfd3c8352edee7ad/msgspec-0.15.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9178a7550a5516295c682e6e5c143782503719b4c816496349a4a0f1b62397ef"},
-    {url = "https://files.pythonhosted.org/packages/8c/77/af7e8fb4e786c6002a47685f9845871740951a5b9135f5a8bb075c7dded0/msgspec-0.15.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8cee590163788fce21c5998d09198ef08ec06c1ca68ef50f2d5ed9e54d308538"},
-    {url = "https://files.pythonhosted.org/packages/92/bc/901267d37597e9a46f31de52cd3647d5cf6a38bc538d981d601c2203cb5d/msgspec-0.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:415519f68cd3f1a224f87ed415459ac3b86e4f6e82815a036e4238c62006f696"},
-    {url = "https://files.pythonhosted.org/packages/97/e7/80135117fa6df9cbab2226f261dc1566878776e25a2e8f3e8bf9f78d1d0e/msgspec-0.15.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c4c7e0abfac3a67f3e1d51e1d1313fd4205528e17663ff264b1945c3370b18bd"},
-    {url = "https://files.pythonhosted.org/packages/a4/67/0c447ba7d362746550f32dfa04beb46ca11460958c7c02b1b4814365f017/msgspec-0.15.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:22713a1f618b4094c0268c6fbeef530397e5f3fa5292e4afd51caddad645843f"},
-    {url = "https://files.pythonhosted.org/packages/a5/18/2eccf2b9b08703fb04b71236357a2dd512fd22974f2a42605fe6ccf7cdbe/msgspec-0.15.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:550b359c49562d52849103b87b4f7381fbc0adf958afa316599befb9a3e3379e"},
-    {url = "https://files.pythonhosted.org/packages/af/43/d851fb8b255dfc5bd04fff6bd43cd5a9d8e4c59adf86201a98134ce89d39/msgspec-0.15.0.tar.gz", hash = "sha256:d760ff747165d84965791bfcd14588f61f111708036d80f1980387e3760035e7"},
-    {url = "https://files.pythonhosted.org/packages/b3/d8/05e26b695f273d6aa21825a964ec5742726f0336486c39f49846fd4fcb15/msgspec-0.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:381c7a891adcc741e617956ba987912bc21864f9dd27b8cfb03bfb0aded5e1fd"},
-    {url = "https://files.pythonhosted.org/packages/c4/25/2fd3c28ccfb3580b3f27372eea38cfe06b414fb30b0a6b0013729e0eb7f6/msgspec-0.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20bf8018bff6bb85f5315ba6fd47b2f9373ab67e8bb59b0d7a7def22bbbf9f70"},
-    {url = "https://files.pythonhosted.org/packages/d1/de/8d6f49160e273a7951baffdfcd8ab4254e1982d7ffdeaa702db59957b8b5/msgspec-0.15.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:cc253e4ad51d360590358ab2cee5a6139f04ad994e0fcbff52e7f61fca475c3e"},
-    {url = "https://files.pythonhosted.org/packages/d6/8c/1dfa0f28a38a20df4ae4511a4788b15a4aee52c8bc394d11e02f8ec3a2ec/msgspec-0.15.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9d61de44b248feef82c8979a1e9912c923527cfb1d01c93b7bb5d6ca93ed09d6"},
-    {url = "https://files.pythonhosted.org/packages/db/fd/a365a273791d32273a65f4beba92384cb71da4253b08961bad8d767018d6/msgspec-0.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:42c2f9fe0b58dc6f2b15720490c67554b5ba0007d3ee94340ca4448bda917287"},
-    {url = "https://files.pythonhosted.org/packages/e2/c3/81ab31bb3ad8225c83a46aeba6829a7b9ec58df92b8b8e003f97acf937c7/msgspec-0.15.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4d3cde786110a92f764666b9f963b4389d5d1798bf1aca2422a59931d8d1f694"},
+"msgspec 0.18.4" = [
+    {url = "https://files.pythonhosted.org/packages/00/e0/9d1d977daab0b812aca7906efc314c2459a82e7bf677f23baefb07b7fffe/msgspec-0.18.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:86800265f87f192a0daefe668e0a9634c35bf8af94b1f297e1352ac62d2e26da"},
+    {url = "https://files.pythonhosted.org/packages/07/05/19a5cca97d516231f472742482a5ca74d1e1fc8e4369dc62ba76cb4f7fb4/msgspec-0.18.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8064908ddb3d95d3261aaca48fd38abb16ccf59dc3f2d01eb4e04591fc1e9bd4"},
+    {url = "https://files.pythonhosted.org/packages/07/78/b87395e71d729bbc0d4c80f46a4e44a07c670917143d84b368ee3be8fad1/msgspec-0.18.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b052fd7d25a8aa2ffde10126ee1d97b4c6f3d81f3f3ab1258ff759a2bd794874"},
+    {url = "https://files.pythonhosted.org/packages/1d/ec/6aad64aa7c5c594f0438712900ee06cc86e09e896d5270b94998f5d81c70/msgspec-0.18.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9714b78965047638c01c818b4b418133d77e849017de17b0655ee37b714b47a6"},
+    {url = "https://files.pythonhosted.org/packages/20/f3/1dbe15ae43206aca30422aa17c7453e38161def22a392ae5a54df2c5b76b/msgspec-0.18.4-cp39-cp39-win_amd64.whl", hash = "sha256:5f446f16ea57d70cceec29b7cb85ec0b3bea032e3dec316806e38575ea3a69b4"},
+    {url = "https://files.pythonhosted.org/packages/26/6a/55121b6c58dd860d74a33e60e4f6a182f1693bfbe1bc7ca74ea83ded4e8b/msgspec-0.18.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b01efbf80a987a99e9079257c893c026dc661d4cd05caa1f7eabf4accc7f1fbc"},
+    {url = "https://files.pythonhosted.org/packages/29/ca/bc51d7d31a7d2b0354370b61ce112c21e63354b104455165e17e7116f56f/msgspec-0.18.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e4294158c233884f3b3220f0e96a30d3e916a4781f9502ae6d477bd57bbc80ad"},
+    {url = "https://files.pythonhosted.org/packages/32/f0/46fbe037444a69a12d662de7b1361311d6ca07f04155facd4ca8205b0fff/msgspec-0.18.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:227fee75a25080a8b3677cdd95b9c0c3652e27869004a084886c65eb558b3dd6"},
+    {url = "https://files.pythonhosted.org/packages/42/09/5cb495456ed7cc3d2dc33100a847bd5e04fa1e2f6d1211a318b4ed984c04/msgspec-0.18.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc2405dba5af6478dedd3512bb92197b6f9d1bc0095655afbe9b54d7a426f19f"},
+    {url = "https://files.pythonhosted.org/packages/51/10/16ce74ff9eb23157af9e9166aea3c078b6fbb607c04c7909cb20254f9c90/msgspec-0.18.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e14287c3405093645b3812e3436598edd383b9ed724c686852e65d569f39f953"},
+    {url = "https://files.pythonhosted.org/packages/53/8a/641d2b2e6ac73c303e9af0b3489abc6c4f2530afb3caf5ac08dbc0aa98aa/msgspec-0.18.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f668102958841c5bbd3ba7cf569a65d17aa3bdcf22124f394dfcfcf53cc5a9b9"},
+    {url = "https://files.pythonhosted.org/packages/63/0e/964ffae76791a56670a506bc6c87ebcae70579e543194f53a832c1370728/msgspec-0.18.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:87bc01949a35970398f5267df8ed4189c340727bb6feec99efdb9969dd05cf30"},
+    {url = "https://files.pythonhosted.org/packages/6b/db/a842284b693a337af449bff384979c493272372215d04dd92f28c0c178cf/msgspec-0.18.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d99f3c13569a5add0980b0d8c6e0bd94a656f6363b26107435b3091df979d228"},
+    {url = "https://files.pythonhosted.org/packages/6b/fd/24d2477ef6f6eff784e0df12e65332ec182e5e5b551dfb54821af1c735df/msgspec-0.18.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:991aa3c76d1b1ec84e840d0b3c96692af834e1f8a1e1a3974cbd189eaf0f2276"},
+    {url = "https://files.pythonhosted.org/packages/6d/ad/8b578ee9520276b422a9c78434f981dd8fff130be2b668d0c80d2531b72a/msgspec-0.18.4-cp311-cp311-win_amd64.whl", hash = "sha256:828ef92f6654915c36ef6c7d8fec92404a13be48f9ff85f060e73b30299bafe1"},
+    {url = "https://files.pythonhosted.org/packages/6f/59/814c3db925c07e9c93c0416f9deda4c5d0fca23da247af3b4593111ac1e7/msgspec-0.18.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:241277eed9fd91037372519fca62aecf823f7229c1d351030d0be5e3302580c1"},
+    {url = "https://files.pythonhosted.org/packages/77/40/c4b840a8df05b7d49e4eb132e45bcff23dce157d57bc61c7f32066440690/msgspec-0.18.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:acdcef2fccfff02f80ac8673dbeab205c288b680d81e05bfb5ae0be6b1502a7e"},
+    {url = "https://files.pythonhosted.org/packages/7c/db/3f7413dc5dc7c3de6d495b9c093939af3ebcaef237c76a1d36810b16e7a2/msgspec-0.18.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:8a198409f672f93534c9c36bdc9eea9fb536827bd63ea846882365516a961356"},
+    {url = "https://files.pythonhosted.org/packages/7e/0d/72c6402825cf1448a3fac3a8c7a9fb75626affba2c62fe4fe372221dcf49/msgspec-0.18.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4d24a291a3c94a7f5e26e8f5ef93e72bf26c10dfeed4d6ae8fc87ead02f4e265"},
+    {url = "https://files.pythonhosted.org/packages/7e/33/7c8a8d9dccc71acfe44bc17cbfb2687a946e4f6de6a301f893912f32bc3d/msgspec-0.18.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bbbc08d59f74de5791bda63569f26a35ae1dd6bd20c55c3ceba5567b0e5a8ef1"},
+    {url = "https://files.pythonhosted.org/packages/88/ae/a74669b026fa960e7c45e1e570267a9fcaae877021e35efd0ef3057387be/msgspec-0.18.4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e95bd0a946b5b7206f27c0f654f490231c9ad5e5a4ff65af8c986f5114dfaf0e"},
+    {url = "https://files.pythonhosted.org/packages/8a/b3/fb78ec80165b5cc93f30d180c4d01d5f4b66fb6aa815ad07b2e0dea97e5b/msgspec-0.18.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:96ccaef83adc0ce96d95328a03289cd5aead4fe400aac21fbe2008855a124a01"},
+    {url = "https://files.pythonhosted.org/packages/8d/1b/a62b8c70df5eac516b9636d405fc6bc5ec1f160a751c30d386be0debafc1/msgspec-0.18.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:da13a06e77d683204eee3b134b08ecd5e4759a79014027b1bcd7a12c614b466d"},
+    {url = "https://files.pythonhosted.org/packages/90/ed/2bf9985a896f9e31402fc6ecd4bec9e7ef4cf85a1142f00308b82ded6ea5/msgspec-0.18.4-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:55e578fd921c88de0d3a209fe5fd392bb66623924c6525b42cea37c72bf8d558"},
+    {url = "https://files.pythonhosted.org/packages/a7/5d/a9ea2e58e3711681c4a9fd5e6392d69edb9c79c8ebdaec5e81b1242330d2/msgspec-0.18.4-cp38-cp38-win_amd64.whl", hash = "sha256:7e95817021db96c43fd81244228e185b13b085cca3d5169af4e2dfe3ff412954"},
+    {url = "https://files.pythonhosted.org/packages/af/88/04611d8365f735ae1ba71b402842afbd336811b4916424f558692c9c4a65/msgspec-0.18.4-cp312-cp312-win_amd64.whl", hash = "sha256:44d551aee1ec8aa2d7b64762557c266bcbf7d5109f2246955718d05becc509d6"},
+    {url = "https://files.pythonhosted.org/packages/bb/ef/ef9f239ceda10528732463f10007295a1a1309e2c00431d84a0658cfb905/msgspec-0.18.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:8476848f4937da8faec53700891694df2e412453cb7445991f0664cdd1e2dd16"},
+    {url = "https://files.pythonhosted.org/packages/bc/34/1fa46c644e89f48ca607d95f75c113c678ad994d3675cb370e2c4caea28f/msgspec-0.18.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:73e70217ff5e4ac244c8f1b0769215cbc81e1c904e135597a5b71162857e6c27"},
+    {url = "https://files.pythonhosted.org/packages/c1/05/10fdb2468cf719ed48e685b69ca9d5a74ce32ec8bc9d3880d1c83556dd4e/msgspec-0.18.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6229dd49438d81ed7a3470e3cbc9646b1cc1b120d415a1786df880dabb1d1c4"},
+    {url = "https://files.pythonhosted.org/packages/c3/d2/a4fe6b545893ceb42ad1e946cb9c6215bc5004d19e5002fc0d1275c23cd3/msgspec-0.18.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:deb11ba2709019192636042df5c8db8738e45946735627021b7e7934714526e4"},
+    {url = "https://files.pythonhosted.org/packages/c4/db/143d1e58ffd80a9a7d0d728478e3376c246a19b56c5dbfd847e5298cbef0/msgspec-0.18.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:826dcb0dfaac0abbcf3a3ae991749900671796eb688b017a69a82bde1e624662"},
+    {url = "https://files.pythonhosted.org/packages/cf/dd/da9a3b344032316c917488d953b5508421b2b09e802573384a8ee3de6be2/msgspec-0.18.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:847d79f6f0b698671ff390aa5a66e207108f2c23b077ef9314ca4fe7819fa4ec"},
+    {url = "https://files.pythonhosted.org/packages/d4/8e/cdec51dc76f6604ec36e48a573693d21a0a4240b0c254059af59f68e79a8/msgspec-0.18.4-cp310-cp310-win_amd64.whl", hash = "sha256:dc25e6100026f5e1ecb5120150f4e78beb909cbeb0eb724b9982361b75c86c6b"},
+    {url = "https://files.pythonhosted.org/packages/ea/fa/b66a0964eac3621fbc10efba04cc6143066e2887e7ad4625df11eaa7d454/msgspec-0.18.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:e21bc5aae6b80dfe4eb75dc1bb29af65483f967d5522e9e3812115a0ba285cac"},
+    {url = "https://files.pythonhosted.org/packages/ef/48/ec6fa869ae5b83cc22cb828919bfbf76f8404829e13bc9b25c69fed85b19/msgspec-0.18.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d08175cbb55c1a87dd258645dce6cd00705d6088bf88e7cf510a9d5c24b0720b"},
+    {url = "https://files.pythonhosted.org/packages/f2/5f/d202be1baac094064d3c4d2bd926b5ff83002fe411410b225d0c88f8c5ba/msgspec-0.18.4.tar.gz", hash = "sha256:cb62030bd6b1a00b01a2fcb09735016011696304e6b1d3321e58022548268d3e"},
 ]
-"mypy-extensions 1.0.0" = [
-    {url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
-    {url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+"packaging 23.2" = [
+    {url = "https://files.pythonhosted.org/packages/ec/1a/610693ac4ee14fcdf2d9bf3c493370e4f2ef7ae2e19217d7a237ff42367d/packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
+    {url = "https://files.pythonhosted.org/packages/fb/2b/9b9c33ffed44ee921d0967086d653047286054117d584f1b1a7c22ceaf7b/packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
 ]
-"packaging 23.1" = [
-    {url = "https://files.pythonhosted.org/packages/ab/c3/57f0601a2d4fe15de7a553c00adbc901425661bf048f2a22dfc500caf121/packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
-    {url = "https://files.pythonhosted.org/packages/b9/6c/7c6658d258d7971c5eb0d9b69fa9265879ec9a9158031206d47800ae2213/packaging-23.1.tar.gz", hash = "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"},
+"pluggy 1.3.0" = [
+    {url = "https://files.pythonhosted.org/packages/05/b8/42ed91898d4784546c5f06c60506400548db3f7a4b3fb441cba4e5c17952/pluggy-1.3.0-py3-none-any.whl", hash = "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"},
+    {url = "https://files.pythonhosted.org/packages/36/51/04defc761583568cae5fd533abda3d40164cbdcf22dee5b7126ffef68a40/pluggy-1.3.0.tar.gz", hash = "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12"},
 ]
-"pathspec 0.11.1" = [
-    {url = "https://files.pythonhosted.org/packages/95/60/d93628975242cc515ab2b8f5b2fc831d8be2eff32f5a1be4776d49305d13/pathspec-0.11.1.tar.gz", hash = "sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687"},
-    {url = "https://files.pythonhosted.org/packages/be/c8/551a803a6ebb174ec1c124e68b449b98a0961f0b737def601e3c1fbb4cfd/pathspec-0.11.1-py3-none-any.whl", hash = "sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"},
+"pytest 7.4.3" = [
+    {url = "https://files.pythonhosted.org/packages/38/d4/174f020da50c5afe9f5963ad0fc5b56a4287e3586e3de5b3c8bce9c547b4/pytest-7.4.3.tar.gz", hash = "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"},
+    {url = "https://files.pythonhosted.org/packages/f3/8c/f16efd81ca8e293b2cc78f111190a79ee539d0d5d36ccd49975cb3beac60/pytest-7.4.3-py3-none-any.whl", hash = "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac"},
 ]
-"platformdirs 3.5.1" = [
-    {url = "https://files.pythonhosted.org/packages/89/7e/c6ff9ddcf93b9b36c90d88111c4db354afab7f9a58c7ac3257fa717f1268/platformdirs-3.5.1-py3-none-any.whl", hash = "sha256:e2378146f1964972c03c085bb5662ae80b2b8c06226c54b2ff4aa9483e8a13a5"},
-    {url = "https://files.pythonhosted.org/packages/9c/0e/ae9ef1049d4b5697e79250c4b2e72796e4152228e67733389868229c92bb/platformdirs-3.5.1.tar.gz", hash = "sha256:412dae91f52a6f84830f39a8078cecd0e866cb72294a5c66808e74d5e88d251f"},
-]
-"pluggy 1.0.0" = [
-    {url = "https://files.pythonhosted.org/packages/9e/01/f38e2ff29715251cf25532b9082a1589ab7e4f571ced434f98d0139336dc/pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
-    {url = "https://files.pythonhosted.org/packages/a1/16/db2d7de3474b6e37cbb9c008965ee63835bba517e22cdb8c35b5116b5ce1/pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
-]
-"pytest 7.3.1" = [
-    {url = "https://files.pythonhosted.org/packages/1b/d1/72df649a705af1e3a09ffe14b0c7d3be1fd730da6b98beb4a2ed26b8a023/pytest-7.3.1-py3-none-any.whl", hash = "sha256:3799fa815351fea3a5e96ac7e503a96fa51cc9942c3753cda7651b93c1cfa362"},
-    {url = "https://files.pythonhosted.org/packages/ec/d9/36b65598f3d19d0a14d13dc87ad5fa42869ae53bb7471f619a30eaabc4bf/pytest-7.3.1.tar.gz", hash = "sha256:434afafd78b1d78ed0addf160ad2b77a30d35d4bdf8af234fe621919d9ed15e3"},
-]
-"ruff 0.0.267" = [
-    {url = "https://files.pythonhosted.org/packages/1e/6c/a5a28b7c4df1316ff0ede0ce51af3a9af76b23c6f19a2d9edcd28036aa8d/ruff-0.0.267-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5a898953949e37c109dd242cfcf9841e065319995ebb7cdfd213b446094a942f"},
-    {url = "https://files.pythonhosted.org/packages/21/80/c68a5d5117f84b6d4892cf8a5e1b164bd5b14bc0894ce0cba5343e40f132/ruff-0.0.267-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9adf1307fa9d840d1acaa477eb04f9702032a483214c409fca9dc46f5f157fe3"},
-    {url = "https://files.pythonhosted.org/packages/3e/52/d1015fa5a13e9bd11b7a4e1147f541e52fe666b550f14e9ca1249bdc447b/ruff-0.0.267-py3-none-musllinux_1_2_i686.whl", hash = "sha256:786de30723c71fc46b80a173c3313fc0dbe73c96bd9da8dd1212cbc2f84cdfb2"},
-    {url = "https://files.pythonhosted.org/packages/45/1e/f423a80da2217137ef3d287aec70d978ae71038cce92cdc61659ebb4a063/ruff-0.0.267-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:2107cec3699ca4d7bd41543dc1d475c97ae3a21ea9212238b5c2088fa8ee7722"},
-    {url = "https://files.pythonhosted.org/packages/53/0c/8897fc309498b48fc60552c714264e91fda10c44defa9401a5c6288cb198/ruff-0.0.267-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbe104f21a429b77eb5ac276bd5352fd8c0e1fbb580b4c772f77ee8c76825654"},
-    {url = "https://files.pythonhosted.org/packages/53/49/fe3e44b5ebd9456e4e0acf79d9c0a777da59f170b7b95e2438f7e10deb15/ruff-0.0.267-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:45d61a2b01bdf61581a2ee039503a08aa603dc74a6bbe6fb5d1ce3052f5370e5"},
-    {url = "https://files.pythonhosted.org/packages/54/e3/eaa63e3a5c03613088ca00857ba4cf6e6e0e7463a183633a2083b167d02f/ruff-0.0.267-py3-none-win_amd64.whl", hash = "sha256:d09aecc9f5845586ba90911d815f9772c5a6dcf2e34be58c6017ecb124534ac4"},
-    {url = "https://files.pythonhosted.org/packages/56/8f/0ea8e8023f2005e86d9177a250ac0bda008143e5d38f3c21301d81fc09ac/ruff-0.0.267-py3-none-win32.whl", hash = "sha256:d12ab329474c46b96d962e2bdb92e3ad2144981fe41b89c7770f370646c0101f"},
-    {url = "https://files.pythonhosted.org/packages/5d/ba/5dfcde964c63c37e825889dc706afd8641c5460a01eeb6764b2440d1ba25/ruff-0.0.267-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f731d81cb939e757b0335b0090f18ca2e9ff8bcc8e6a1cf909245958949b6e11"},
-    {url = "https://files.pythonhosted.org/packages/67/85/249e6d52ed6272cdb9785e00bd8f1f7b7ac9ed3285c42300137faabb50ae/ruff-0.0.267-py3-none-win_arm64.whl", hash = "sha256:7df7eb5f8d791566ba97cc0b144981b9c080a5b861abaf4bb35a26c8a77b83e9"},
-    {url = "https://files.pythonhosted.org/packages/6d/7d/1c3a89baa73a7880db0706092b668061c172cda6a7ac510646af54bd746a/ruff-0.0.267-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:67254ae34c38cba109fdc52e4a70887de1f850fb3971e5eeef343db67305d1c1"},
-    {url = "https://files.pythonhosted.org/packages/96/e4/c9a745407e204e755fa39a1819dc602662fef90fd9b00f44aac3b4d67176/ruff-0.0.267-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:0afca3633c8e2b6c0a48ad0061180b641b3b404d68d7e6736aab301c8024c424"},
-    {url = "https://files.pythonhosted.org/packages/b8/3e/ef28832b87a177b3815c6e1fbe314498359122d671e8d80eca22a933784f/ruff-0.0.267-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20c594eb56c19063ef5a57f89340e64c6550e169d6a29408a45130a8c3068adc"},
-    {url = "https://files.pythonhosted.org/packages/d9/da/ee9b62a02de95d716522095e62e7b2fb94dba13d9943e27400c59813bfb5/ruff-0.0.267.tar.gz", hash = "sha256:632cec7bbaf3c06fcf0a72a1dd029b7d8b7f424ba95a574aaa135f5d20a00af7"},
-    {url = "https://files.pythonhosted.org/packages/f1/7a/08f4803d440ee8fac3f007ca41e1a061fa529833c90b3b8dd37662393bbf/ruff-0.0.267-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:db33deef2a5e1cf528ca51cc59dd764122a48a19a6c776283b223d147041153f"},
-    {url = "https://files.pythonhosted.org/packages/fa/25/cd00b70d749cff37dc567e7267926211ddfaeb8b4eb05aed43d0decfceea/ruff-0.0.267-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2972241065b1c911bce3db808837ed10f4f6f8a8e15520a4242d291083605ab6"},
-    {url = "https://files.pythonhosted.org/packages/fb/09/6db9f4e8f5dbbe82a72abf2b89cc2bd5033ebee9767187428061e93b4e17/ruff-0.0.267-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:4adbbbe314d8fcc539a245065bad89446a3cef2e0c9cf70bf7bb9ed6fe31856d"},
+"ruff 0.1.3" = [
+    {url = "https://files.pythonhosted.org/packages/1d/e7/67d70e1ca3faaaa644aeb411bf8ebdc56e1e9ec8755c201eb524ace9d258/ruff-0.1.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eec2dd31eed114e48ea42dbffc443e9b7221976554a504767ceaee3dd38edeb8"},
+    {url = "https://files.pythonhosted.org/packages/2c/02/80015e8c9071ba62a3baba5349a6491facf2ed06a95e8abdc8bd066c4c21/ruff-0.1.3-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:b46d43d51f7061652eeadb426a9e3caa1e0002470229ab2fc19de8a7b0766901"},
+    {url = "https://files.pythonhosted.org/packages/32/ec/860ac4dc8ee5c3c59222ac1f0bf1ed4c00e5311b4ef0471e7db8863d3b40/ruff-0.1.3-py3-none-win_amd64.whl", hash = "sha256:7a18df6638cec4a5bd75350639b2bb2a2366e01222825562c7346674bdceb7ea"},
+    {url = "https://files.pythonhosted.org/packages/46/48/65fdda6019ee65b671a8ea20e418bc482472d49631a48143158838370094/ruff-0.1.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca3cf365bf32e9ba7e6db3f48a4d3e2c446cd19ebee04f05338bc3910114528b"},
+    {url = "https://files.pythonhosted.org/packages/4a/70/861d979161e956ef679ad4b21026fae678170a1d3b71697aafd617ac6aea/ruff-0.1.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e3de9ed2e39160800281848ff4670e1698037ca039bda7b9274f849258d26ce"},
+    {url = "https://files.pythonhosted.org/packages/4e/b7/4f6317a42d2a2e68a5dafa9366849ca7eb11e7292e8f9ad2142d9c086fcb/ruff-0.1.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c595193881922cc0556a90f3af99b1c5681f0c552e7a2a189956141d8666fe8"},
+    {url = "https://files.pythonhosted.org/packages/78/52/870699377b0ba4f6328c0d9c5360c34f47fdecb236890219d6bdb95c9ef1/ruff-0.1.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4874c165f96c14a00590dcc727a04dca0cfd110334c24b039458c06cf78a672e"},
+    {url = "https://files.pythonhosted.org/packages/78/e5/cb9cef0dafdcfd51941d145df0a8ce9ea930e1f85da7f25bb6886d4681b2/ruff-0.1.3.tar.gz", hash = "sha256:3ba6145369a151401d5db79f0a47d50e470384d0d89d0d6f7fab0b589ad07c34"},
+    {url = "https://files.pythonhosted.org/packages/9d/f7/e8c6a715abab1d8b8f8fc3b65e51a33eb8cdf39c42358de0ad6125299be1/ruff-0.1.3-py3-none-win_arm64.whl", hash = "sha256:12fd53696c83a194a2db7f9a46337ce06445fb9aa7d25ea6f293cf75b21aca9f"},
+    {url = "https://files.pythonhosted.org/packages/9e/d5/41dc69d92550309d7f00662444bf62aeea27b0399c1a3be6ffa12a8a96b9/ruff-0.1.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d8859605e729cd5e53aa38275568dbbdb4fe882d2ea2714c5453b678dca83784"},
+    {url = "https://files.pythonhosted.org/packages/ac/c7/8bbeb18581fa94beb01646a8434e58ea48e9cec45d7768e258e16d43f247/ruff-0.1.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f75e670d529aa2288cd00fc0e9b9287603d95e1536d7a7e0cafe00f75e0dd9d"},
+    {url = "https://files.pythonhosted.org/packages/ba/59/cc7fbefcf7e0cccae177f18486af74be8a79b8d4b73679b8f2dca7dc86db/ruff-0.1.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:dc3ec4edb3b73f21b4aa51337e16674c752f1d76a4a543af56d7d04e97769613"},
+    {url = "https://files.pythonhosted.org/packages/cb/c1/4e35bdfce766d6270611263950c31c43011109dd4a1f6b920eff0a8f4a12/ruff-0.1.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:918b454bc4f8874a616f0d725590277c42949431ceb303950e87fef7a7d94cb3"},
+    {url = "https://files.pythonhosted.org/packages/dc/d6/efe8693e2ba03d4872eb510cf3f0a82e9be1b75ff7cbcd7033287a511c30/ruff-0.1.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:76dd49f6cd945d82d9d4a9a6622c54a994689d8d7b22fa1322983389b4892e20"},
+    {url = "https://files.pythonhosted.org/packages/dd/42/2a0d4abb0a7050d0267336d6ff2eb8f3b08ea90908e40712892abc10a399/ruff-0.1.3-py3-none-win32.whl", hash = "sha256:3e7afcbdcfbe3399c34e0f6370c30f6e529193c731b885316c5a09c9e4317eef"},
+    {url = "https://files.pythonhosted.org/packages/ee/4d/7dd94caca7b5e7ac1cdc395f65c9220f5fc6e5825b7d205ed711296e9475/ruff-0.1.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0b6c55f5ef8d9dd05b230bb6ab80bc4381ecb60ae56db0330f660ea240cb0d4a"},
+    {url = "https://files.pythonhosted.org/packages/f4/c7/b7127a11b84e4b813056dffe0281d7a808087dcdbe55bd03dddd9269ed92/ruff-0.1.3-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:b8afeb9abd26b4029c72adc9921b8363374f4e7edb78385ffaa80278313a15f9"},
 ]
 "tomli 2.0.1" = [
     {url = "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {url = "https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
-"typing-extensions 4.5.0" = [
-    {url = "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl", hash = "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"},
-    {url = "https://files.pythonhosted.org/packages/d3/20/06270dac7316220643c32ae61694e451c98f8caf4c8eab3aa80a2bedf0df/typing_extensions-4.5.0.tar.gz", hash = "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,15 +34,11 @@ test = [
     "pytest>=7.3.1",
 ]
 [tool.pdm.scripts]
-black = "black --check llmspec"
-ruff = "ruff check ."
-lint = { composite = ["black", "ruff"] }
+lint = "ruff check ."
+format = "ruff format ."
 
 [tool.ruff]
 line-length = 88
 select = ["E", "F", "B", "I", "SIM", "TID", "PL"]
 [tool.ruff.pylint]
 max-args = 7
-
-[tool.black]
-line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "msgspec>=0.15.0",
+    "msgspec>=0.18.4",
 ]
 requires-python = ">=3.8"
 readme = "README.md"
@@ -27,8 +27,7 @@ write_template = """__version__ = "{}"
 """
 [tool.pdm.dev-dependencies]
 lint = [
-    "ruff>=0.0.267",
-    "black>=23.3.0",
+    "ruff>=0.1.3",
 ]
 test = [
     "pytest>=7.3.1",

--- a/tests/dummy_test.py
+++ b/tests/dummy_test.py
@@ -1,2 +1,0 @@
-def test_dummy():
-    assert True

--- a/tests/prompt_test.py
+++ b/tests/prompt_test.py
@@ -85,8 +85,8 @@ question, please don't share false information.
                 " [INST] Who are you? [/INST] "
                 " I'm a bot."
                 " [INST] Do you like English? [/INST] "
-            )
-        )
+            ),
+        ),
     ],
     indirect=["messages"],
 )

--- a/tests/struct_test.py
+++ b/tests/struct_test.py
@@ -1,0 +1,38 @@
+import json
+
+import pytest
+from msgspec import ValidationError
+
+from llmspec import EmbeddingRequest
+
+
+@pytest.mark.parametrize(
+    "text,exception",
+    [
+        (
+            json.dumps({"model": "text-embedding-ada-002", "input": "single sentence"}),
+            None,
+        ),
+        (
+            json.dumps({"model": "text-embedding-ada-002", "input": ["list", "list"]}),
+            None,
+        ),
+        (json.dumps({"model": "text-embedding-ada-002", "input": [[0, 233]]}), None),
+        (
+            json.dumps({"model": "text-embedding-ada-002", "input": [[0, 233], [0]]}),
+            None,
+        ),
+        (
+            json.dumps({"model": "text-embedding-ada-002", "input": 233}),
+            ValidationError,
+        ),
+        (json.dumps({"input": "missing-model-name"}), ValidationError),
+        (json.dumps({"model": "text-embedding-ada-002"}), ValidationError),
+    ],
+)
+def test_embedding_request(text, exception):
+    if exception is None:
+        EmbeddingRequest.from_bytes(text)
+    else:
+        with pytest.raises(exception):
+            EmbeddingRequest.from_bytes(text)


### PR DESCRIPTION
The request can be:

```json
{
  "model": "text-embedding-ada-002",
  "input": [
    [20, 344, 1243],
    [321, 111, 233]
  ]
}
```